### PR TITLE
Auth service functionality: token renew

### DIFF
--- a/auth-service/src/lib/tokens.ts
+++ b/auth-service/src/lib/tokens.ts
@@ -58,3 +58,15 @@ export const createAccessToken = (account: IAccount, aud = config.audience) => {
         config.accessToken.secret,
     );
 };
+
+export const verifyToken = (token: string, secret: string): Promise<any> => {
+    return new Promise((resolve, reject) => {
+        jwt.verify(token, secret, async (err, decoded: any) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded);
+            }
+        });
+    });
+};

--- a/auth-service/src/proto/auth/auth_service.proto
+++ b/auth-service/src/proto/auth/auth_service.proto
@@ -11,7 +11,7 @@ service Auth {
     rpc SignIn(UserCredentials) returns (SignInResponse) {}
 
     // Get a new pair of access and refresh tokens
-    rpc RenewToken(RenewRequest) returns (JWTTokens) {}
+    rpc RenewToken(RenewRequest) returns (RenewResponse) {}
 
     // Get account details based on access token
     rpc GetAccount(AccountRequest) returns (AccountInfo) {}
@@ -33,6 +33,8 @@ enum AuthErrorStatus {
     SERVER_ERROR = 0;
     NOT_FOUND = 1;
     BAD_CREDENTIALS = 2;
+    INVALID_TOKEN = 3;
+    EXPIRED_TOKEN = 4;
 }
 
 message SignUpResponse {
@@ -58,6 +60,13 @@ message JWTTokens {
 
 message RenewRequest {
     string refresh_token = 1;
+}
+
+message RenewResponse {
+    oneof status {
+        JWTTokens tokens = 1;
+        AuthErrorStatus error = 2;
+    }
 }
 
 message AccountRequest {

--- a/auth-service/src/proto/auth/auth_service_grpc_pb.d.ts
+++ b/auth-service/src/proto/auth/auth_service_grpc_pb.d.ts
@@ -32,14 +32,14 @@ interface IAuthService_ISignIn extends grpc.MethodDefinition<auth_service_pb.Use
     responseSerialize: grpc.serialize<auth_service_pb.SignInResponse>;
     responseDeserialize: grpc.deserialize<auth_service_pb.SignInResponse>;
 }
-interface IAuthService_IRenewToken extends grpc.MethodDefinition<auth_service_pb.RenewRequest, auth_service_pb.JWTTokens> {
+interface IAuthService_IRenewToken extends grpc.MethodDefinition<auth_service_pb.RenewRequest, auth_service_pb.RenewResponse> {
     path: string; // "/.Auth/RenewToken"
     requestStream: boolean; // false
     responseStream: boolean; // false
     requestSerialize: grpc.serialize<auth_service_pb.RenewRequest>;
     requestDeserialize: grpc.deserialize<auth_service_pb.RenewRequest>;
-    responseSerialize: grpc.serialize<auth_service_pb.JWTTokens>;
-    responseDeserialize: grpc.deserialize<auth_service_pb.JWTTokens>;
+    responseSerialize: grpc.serialize<auth_service_pb.RenewResponse>;
+    responseDeserialize: grpc.deserialize<auth_service_pb.RenewResponse>;
 }
 interface IAuthService_IGetAccount extends grpc.MethodDefinition<auth_service_pb.AccountRequest, auth_service_pb.AccountInfo> {
     path: string; // "/.Auth/GetAccount"
@@ -56,7 +56,7 @@ export const AuthService: IAuthService;
 export interface IAuthServer {
     signUp: grpc.handleUnaryCall<auth_service_pb.NewAccount, auth_service_pb.SignUpResponse>;
     signIn: grpc.handleUnaryCall<auth_service_pb.UserCredentials, auth_service_pb.SignInResponse>;
-    renewToken: grpc.handleUnaryCall<auth_service_pb.RenewRequest, auth_service_pb.JWTTokens>;
+    renewToken: grpc.handleUnaryCall<auth_service_pb.RenewRequest, auth_service_pb.RenewResponse>;
     getAccount: grpc.handleUnaryCall<auth_service_pb.AccountRequest, auth_service_pb.AccountInfo>;
 }
 
@@ -67,9 +67,9 @@ export interface IAuthClient {
     signIn(request: auth_service_pb.UserCredentials, callback: (error: grpc.ServiceError | null, response: auth_service_pb.SignInResponse) => void): grpc.ClientUnaryCall;
     signIn(request: auth_service_pb.UserCredentials, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.SignInResponse) => void): grpc.ClientUnaryCall;
     signIn(request: auth_service_pb.UserCredentials, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.SignInResponse) => void): grpc.ClientUnaryCall;
-    renewToken(request: auth_service_pb.RenewRequest, callback: (error: grpc.ServiceError | null, response: auth_service_pb.JWTTokens) => void): grpc.ClientUnaryCall;
-    renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.JWTTokens) => void): grpc.ClientUnaryCall;
-    renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.JWTTokens) => void): grpc.ClientUnaryCall;
+    renewToken(request: auth_service_pb.RenewRequest, callback: (error: grpc.ServiceError | null, response: auth_service_pb.RenewResponse) => void): grpc.ClientUnaryCall;
+    renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.RenewResponse) => void): grpc.ClientUnaryCall;
+    renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.RenewResponse) => void): grpc.ClientUnaryCall;
     getAccount(request: auth_service_pb.AccountRequest, callback: (error: grpc.ServiceError | null, response: auth_service_pb.AccountInfo) => void): grpc.ClientUnaryCall;
     getAccount(request: auth_service_pb.AccountRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.AccountInfo) => void): grpc.ClientUnaryCall;
     getAccount(request: auth_service_pb.AccountRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.AccountInfo) => void): grpc.ClientUnaryCall;
@@ -83,9 +83,9 @@ export class AuthClient extends grpc.Client implements IAuthClient {
     public signIn(request: auth_service_pb.UserCredentials, callback: (error: grpc.ServiceError | null, response: auth_service_pb.SignInResponse) => void): grpc.ClientUnaryCall;
     public signIn(request: auth_service_pb.UserCredentials, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.SignInResponse) => void): grpc.ClientUnaryCall;
     public signIn(request: auth_service_pb.UserCredentials, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.SignInResponse) => void): grpc.ClientUnaryCall;
-    public renewToken(request: auth_service_pb.RenewRequest, callback: (error: grpc.ServiceError | null, response: auth_service_pb.JWTTokens) => void): grpc.ClientUnaryCall;
-    public renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.JWTTokens) => void): grpc.ClientUnaryCall;
-    public renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.JWTTokens) => void): grpc.ClientUnaryCall;
+    public renewToken(request: auth_service_pb.RenewRequest, callback: (error: grpc.ServiceError | null, response: auth_service_pb.RenewResponse) => void): grpc.ClientUnaryCall;
+    public renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.RenewResponse) => void): grpc.ClientUnaryCall;
+    public renewToken(request: auth_service_pb.RenewRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.RenewResponse) => void): grpc.ClientUnaryCall;
     public getAccount(request: auth_service_pb.AccountRequest, callback: (error: grpc.ServiceError | null, response: auth_service_pb.AccountInfo) => void): grpc.ClientUnaryCall;
     public getAccount(request: auth_service_pb.AccountRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: auth_service_pb.AccountInfo) => void): grpc.ClientUnaryCall;
     public getAccount(request: auth_service_pb.AccountRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: auth_service_pb.AccountInfo) => void): grpc.ClientUnaryCall;

--- a/auth-service/src/proto/auth/auth_service_grpc_pb.js
+++ b/auth-service/src/proto/auth/auth_service_grpc_pb.js
@@ -26,17 +26,6 @@ function deserialize_AccountRequest(buffer_arg) {
   return auth_service_pb.AccountRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_JWTTokens(arg) {
-  if (!(arg instanceof auth_service_pb.JWTTokens)) {
-    throw new Error('Expected argument of type JWTTokens');
-  }
-  return Buffer.from(arg.serializeBinary());
-}
-
-function deserialize_JWTTokens(buffer_arg) {
-  return auth_service_pb.JWTTokens.deserializeBinary(new Uint8Array(buffer_arg));
-}
-
 function serialize_NewAccount(arg) {
   if (!(arg instanceof auth_service_pb.NewAccount)) {
     throw new Error('Expected argument of type NewAccount');
@@ -57,6 +46,17 @@ function serialize_RenewRequest(arg) {
 
 function deserialize_RenewRequest(buffer_arg) {
   return auth_service_pb.RenewRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_RenewResponse(arg) {
+  if (!(arg instanceof auth_service_pb.RenewResponse)) {
+    throw new Error('Expected argument of type RenewResponse');
+  }
+  return Buffer.from(arg.serializeBinary());
+}
+
+function deserialize_RenewResponse(buffer_arg) {
+  return auth_service_pb.RenewResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
 function serialize_SignInResponse(arg) {
@@ -125,11 +125,11 @@ renewToken: {
     requestStream: false,
     responseStream: false,
     requestType: auth_service_pb.RenewRequest,
-    responseType: auth_service_pb.JWTTokens,
+    responseType: auth_service_pb.RenewResponse,
     requestSerialize: serialize_RenewRequest,
     requestDeserialize: deserialize_RenewRequest,
-    responseSerialize: serialize_JWTTokens,
-    responseDeserialize: deserialize_JWTTokens,
+    responseSerialize: serialize_RenewResponse,
+    responseDeserialize: deserialize_RenewResponse,
   },
   // Get account details based on access token
 getAccount: {

--- a/auth-service/src/proto/auth/auth_service_pb.d.ts
+++ b/auth-service/src/proto/auth/auth_service_pb.d.ts
@@ -199,6 +199,49 @@ export namespace RenewRequest {
     }
 }
 
+export class RenewResponse extends jspb.Message { 
+
+    hasTokens(): boolean;
+    clearTokens(): void;
+    getTokens(): JWTTokens | undefined;
+    setTokens(value?: JWTTokens): void;
+
+
+    hasError(): boolean;
+    clearError(): void;
+    getError(): AuthErrorStatus;
+    setError(value: AuthErrorStatus): void;
+
+
+    getStatusCase(): RenewResponse.StatusCase;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): RenewResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: RenewResponse): RenewResponse.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: RenewResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): RenewResponse;
+    static deserializeBinaryFromReader(message: RenewResponse, reader: jspb.BinaryReader): RenewResponse;
+}
+
+export namespace RenewResponse {
+    export type AsObject = {
+        tokens?: JWTTokens.AsObject,
+        error: AuthErrorStatus,
+    }
+
+    export enum StatusCase {
+        STATUS_NOT_SET = 0,
+    
+    TOKENS = 1,
+
+    ERROR = 2,
+
+    }
+
+}
+
 export class AccountRequest extends jspb.Message { 
     getAccessToken(): string;
     setAccessToken(value: string): void;
@@ -224,4 +267,6 @@ export enum AuthErrorStatus {
     SERVER_ERROR = 0,
     NOT_FOUND = 1,
     BAD_CREDENTIALS = 2,
+    INVALID_TOKEN = 3,
+    EXPIRED_TOKEN = 4,
 }

--- a/auth-service/src/proto/auth/auth_service_pb.js
+++ b/auth-service/src/proto/auth/auth_service_pb.js
@@ -17,6 +17,7 @@ goog.exportSymbol('proto.AuthErrorStatus', null, global);
 goog.exportSymbol('proto.JWTTokens', null, global);
 goog.exportSymbol('proto.NewAccount', null, global);
 goog.exportSymbol('proto.RenewRequest', null, global);
+goog.exportSymbol('proto.RenewResponse', null, global);
 goog.exportSymbol('proto.SignInResponse', null, global);
 goog.exportSymbol('proto.SignUpResponse', null, global);
 goog.exportSymbol('proto.UserCredentials', null, global);
@@ -1271,6 +1272,232 @@ proto.RenewRequest.prototype.setRefreshToken = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
+proto.RenewResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, proto.RenewResponse.oneofGroups_);
+};
+goog.inherits(proto.RenewResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.RenewResponse.displayName = 'proto.RenewResponse';
+}
+/**
+ * Oneof group definitions for this message. Each group defines the field
+ * numbers belonging to that group. When of these fields' value is set, all
+ * other fields in the group are cleared. During deserialization, if multiple
+ * fields are encountered for a group, only the last value seen will be kept.
+ * @private {!Array<!Array<number>>}
+ * @const
+ */
+proto.RenewResponse.oneofGroups_ = [[1,2]];
+
+/**
+ * @enum {number}
+ */
+proto.RenewResponse.StatusCase = {
+  STATUS_NOT_SET: 0,
+  TOKENS: 1,
+  ERROR: 2
+};
+
+/**
+ * @return {proto.RenewResponse.StatusCase}
+ */
+proto.RenewResponse.prototype.getStatusCase = function() {
+  return /** @type {proto.RenewResponse.StatusCase} */(jspb.Message.computeOneofCase(this, proto.RenewResponse.oneofGroups_[0]));
+};
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.RenewResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.RenewResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.RenewResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.RenewResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    tokens: (f = msg.getTokens()) && proto.JWTTokens.toObject(includeInstance, f),
+    error: jspb.Message.getFieldWithDefault(msg, 2, 0)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.RenewResponse}
+ */
+proto.RenewResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.RenewResponse;
+  return proto.RenewResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.RenewResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.RenewResponse}
+ */
+proto.RenewResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.JWTTokens;
+      reader.readMessage(value,proto.JWTTokens.deserializeBinaryFromReader);
+      msg.setTokens(value);
+      break;
+    case 2:
+      var value = /** @type {!proto.AuthErrorStatus} */ (reader.readEnum());
+      msg.setError(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.RenewResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.RenewResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.RenewResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.RenewResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getTokens();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.JWTTokens.serializeBinaryToWriter
+    );
+  }
+  f = /** @type {!proto.AuthErrorStatus} */ (jspb.Message.getField(message, 2));
+  if (f != null) {
+    writer.writeEnum(
+      2,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional JWTTokens tokens = 1;
+ * @return {?proto.JWTTokens}
+ */
+proto.RenewResponse.prototype.getTokens = function() {
+  return /** @type{?proto.JWTTokens} */ (
+    jspb.Message.getWrapperField(this, proto.JWTTokens, 1));
+};
+
+
+/** @param {?proto.JWTTokens|undefined} value */
+proto.RenewResponse.prototype.setTokens = function(value) {
+  jspb.Message.setOneofWrapperField(this, 1, proto.RenewResponse.oneofGroups_[0], value);
+};
+
+
+proto.RenewResponse.prototype.clearTokens = function() {
+  this.setTokens(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.RenewResponse.prototype.hasTokens = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional AuthErrorStatus error = 2;
+ * @return {!proto.AuthErrorStatus}
+ */
+proto.RenewResponse.prototype.getError = function() {
+  return /** @type {!proto.AuthErrorStatus} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+};
+
+
+/** @param {!proto.AuthErrorStatus} value */
+proto.RenewResponse.prototype.setError = function(value) {
+  jspb.Message.setOneofField(this, 2, proto.RenewResponse.oneofGroups_[0], value);
+};
+
+
+proto.RenewResponse.prototype.clearError = function() {
+  jspb.Message.setOneofField(this, 2, proto.RenewResponse.oneofGroups_[0], undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.RenewResponse.prototype.hasError = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
 proto.AccountRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
@@ -1408,7 +1635,9 @@ proto.AccountRequest.prototype.setAccessToken = function(value) {
 proto.AuthErrorStatus = {
   SERVER_ERROR: 0,
   NOT_FOUND: 1,
-  BAD_CREDENTIALS: 2
+  BAD_CREDENTIALS: 2,
+  INVALID_TOKEN: 3,
+  EXPIRED_TOKEN: 4
 };
 
 goog.object.extend(exports, proto);


### PR DESCRIPTION
- Added implementation and proto definitions for renewing tokens with refreshtoken
- Added utility function for token verification

note: I'll change the `jwt.verify()` calls to the use utility function in other pr 