### PR TITLE
Image caching headers to the image data API

### DIFF
--- a/image-service/conf/config.json
+++ b/image-service/conf/config.json
@@ -11,5 +11,7 @@
   "MONGO_PASSWORD": "image-service",
   "IMAGES_COLLECTION": "image_meta",
   "KAFKA_SERVERS": "localhost:29092",
-  "IMAGES_TOPIC": "images"
+  "IMAGES_TOPIC": "images",
+  "USERS_TOPIC": "users",
+  "KAFKA_CONSUMER_GROUP": "image-service"
 }

--- a/image-service/conf/config.json
+++ b/image-service/conf/config.json
@@ -10,5 +10,6 @@
   "MONGO_USER": "image-service",
   "MONGO_PASSWORD": "image-service",
   "IMAGES_COLLECTION": "image_meta",
-  "KAFKA_SERVERS": "localhost:29092"
+  "KAFKA_SERVERS": "localhost:29092",
+  "IMAGES_TOPIC": "images"
 }

--- a/image-service/docker-compose.yml
+++ b/image-service/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       MONGO_DATABASE: images
       IMAGES_COLLECTION: image_meta
       KAFKA_SERVERS: kafka-dev:9092
+      IMAGES_TOPIC: images
 
   image-db:
     container_name: image-db-dev

--- a/image-service/docker-compose.yml
+++ b/image-service/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       IMAGES_COLLECTION: image_meta
       KAFKA_SERVERS: kafka-dev:9092
       IMAGES_TOPIC: images
+      USERS_TOPIC: users
+      KAFKA_CONSUMER_GROUP: image-service
 
   image-db:
     container_name: image-db-dev

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
@@ -85,6 +85,12 @@ class AppConfig private constructor(json: JsonObject) {
   var kafkaServers: String
     private set
 
+  /**
+   * Kafka topic for images
+   */
+  var imagesTopic: String
+    private set
+
   init {
     grpcHost = json.getString(ConfigConstants.GRPC_HOST)
     grpcPort = json.getInteger(ConfigConstants.GRPC_PORT)
@@ -99,6 +105,7 @@ class AppConfig private constructor(json: JsonObject) {
     imagesCollection = json.getString(ConfigConstants.IMAGES_COLLECTION, "image_meta")
     likesCollection = json.getString(ConfigConstants.LIKES_COLLECTION, "image_likes")
     kafkaServers = json.getString(ConfigConstants.KAFKA_SERVERS)
+    imagesTopic = json.getString(ConfigConstants.IMAGES_TOPIC, "images")
   }
 
   companion object {

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
@@ -91,6 +91,18 @@ class AppConfig private constructor(json: JsonObject) {
   var imagesTopic: String
     private set
 
+  /**
+   * Kafka topic for users
+   */
+  var usersTopic: String
+    private set
+
+  /**
+   * Name / ID of the Kafka consumer group
+   */
+  var consumerGroup: String
+    private set
+
   init {
     grpcHost = json.getString(ConfigConstants.GRPC_HOST)
     grpcPort = json.getInteger(ConfigConstants.GRPC_PORT)
@@ -106,6 +118,8 @@ class AppConfig private constructor(json: JsonObject) {
     likesCollection = json.getString(ConfigConstants.LIKES_COLLECTION, "image_likes")
     kafkaServers = json.getString(ConfigConstants.KAFKA_SERVERS)
     imagesTopic = json.getString(ConfigConstants.IMAGES_TOPIC, "images")
+    usersTopic = json.getString(ConfigConstants.USERS_TOPIC, "users")
+    consumerGroup = json.getString(ConfigConstants.KAFKA_CONSUMER_GROUP, "image-service")
   }
 
   companion object {

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
@@ -74,4 +74,14 @@ object ConfigConstants {
    * Kafka topic for image events
    */
   const val IMAGES_TOPIC = "IMAGES_TOPIC"
+
+  /**
+   * Kafka topic for user events
+   */
+  const val USERS_TOPIC = "USERS_TOPIC"
+
+  /**
+   * Name / ID of the Kafka consumer group
+   */
+  const val KAFKA_CONSUMER_GROUP = "KAFKA_CONSUMER_GROUP"
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
@@ -69,4 +69,9 @@ object ConfigConstants {
    * Kafka servers value in form of "<host>:<port>"
    */
   const val KAFKA_SERVERS = "KAFKA_SERVERS"
+
+  /**
+   * Kafka topic for image events
+   */
+  const val IMAGES_TOPIC = "IMAGES_TOPIC"
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/DomainEvents.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/DomainEvents.kt
@@ -1,26 +1,34 @@
 package com.instagram_clone.image_service.message_broker
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.vertx.core.json.JsonObject
 
 /**
  * Domain event type for resources
  */
 enum class DomainEventType(val stringValue: String) {
+  @JsonProperty("CREATED")
   Created("CREATED"),
-  Updated("UPDATED"),
+
+  @JsonProperty("DELETED")
   Deleted("DELETED"),
-  Liked("LIKED")
+
+  @JsonProperty("LIKED")
+  Liked("LIKED"),
+
+  @JsonProperty("NOT_SET")
+  NotSet("NOT_SET")
 }
 
 data class DomainEvent(
-  val type: DomainEventType,
-  val entity: Any
+  val type: DomainEventType = DomainEventType.NotSet,
+  val data: Any = ""
 ) : BrokerEvent {
 
   override fun jsonSerialize(): String {
     return JsonObject()
       .put("type", type.stringValue)
-      .put("data", JsonObject.mapFrom(entity))
+      .put("data", JsonObject.mapFrom(data))
       .encode()
   }
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
@@ -42,6 +42,7 @@ class KafkaService(
             val valueAsJson = JsonObject(record.value())
             val event = valueAsJson.mapTo(DomainEvent::class.java)
             handler(event)
+            consumer.commit()
           } catch (e: DecodeException) {
             logger.warn("Kafka consumer event received in unexpected format, ${e.message}", e)
           } catch (e: Exception) {

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
@@ -1,6 +1,9 @@
 package com.instagram_clone.image_service.message_broker
 
+import io.vertx.core.json.DecodeException
+import io.vertx.core.json.JsonObject
 import io.vertx.core.logging.LoggerFactory
+import io.vertx.kafka.client.consumer.KafkaConsumer
 import io.vertx.kafka.client.producer.KafkaProducer
 import io.vertx.kafka.client.producer.KafkaProducerRecord
 
@@ -8,7 +11,8 @@ import io.vertx.kafka.client.producer.KafkaProducerRecord
  * Kafka message broker service class.
  */
 class KafkaService(
-  private val producer: KafkaProducer<Nothing, String>
+  private val producer: KafkaProducer<Nothing, String>,
+  private val consumer: KafkaConsumer<Nothing, String>
 ) : MessageBrokerService {
 
   private val logger = LoggerFactory.getLogger("KafkaService")
@@ -23,6 +27,29 @@ class KafkaService(
     producer.send(record) {
       if (!it.succeeded()) {
         logger.error("Failed to publish event to kafka topic $queue", it.cause())
+      }
+    }
+  }
+
+  /**
+   * Subscribe to given [queue].
+   */
+  override fun subscribe(queue: String, handler: (ar: DomainEvent) -> Unit) {
+    consumer.subscribe(queue) {
+      if (it.succeeded()) {
+        consumer.handler { record ->
+          try {
+            val valueAsJson = JsonObject(record.value())
+            val event = valueAsJson.mapTo(DomainEvent::class.java)
+            handler(event)
+          } catch (e: DecodeException) {
+            logger.warn("Kafka consumer event received in unexpected format, ${e.message}", e)
+          } catch (e: Exception) {
+            logger.error("Unexpected exception while handling consumer event: ${e.message}", e)
+          }
+        }
+      } else {
+        logger.error("Failed to subscribe to queue \"$queue\"")
       }
     }
   }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/MessageBrokerService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/MessageBrokerService.kt
@@ -9,4 +9,9 @@ interface MessageBrokerService {
    * Publish an [event] to [queue].
    */
   fun publishEvent(queue: String, event: BrokerEvent)
+
+  /**
+   * Subscribe to given [queue].
+   */
+  fun subscribe(queue: String, handler: (ar: DomainEvent) -> Unit)
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileService.kt
@@ -22,4 +22,9 @@ interface ImageFileService {
    * Get image file from disk.
    */
   fun getImageFile(id: String): Future<ByteArray>
+
+  /**
+   * Delete a batch of images from disk.
+   */
+  fun deleteImageFiles(ids: List<String>): Future<Int>
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileServiceVertxImpl.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileServiceVertxImpl.kt
@@ -2,6 +2,7 @@ package com.instagram_clone.image_service.service
 
 import com.instagram_clone.image_service.config.AppConfig
 import com.instagram_clone.image_service.exception.NotFoundException
+import io.vertx.core.CompositeFuture
 import io.vertx.core.Future
 import io.vertx.core.Promise
 import io.vertx.core.Vertx
@@ -61,6 +62,11 @@ class ImageFileServiceVertxImpl(
         }
       }
     return promise.future()
+  }
+
+  override fun deleteImageFiles(ids: List<String>): Future<Int> {
+    return CompositeFuture.join(ids.map { deleteImageFile(it) })
+      .compose { Future.succeededFuture(ids.size) }
   }
 
   /**

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaService.kt
@@ -47,4 +47,9 @@ interface ImageMetaService {
    * Get images based on search tag.
    */
   fun searchImagesByTag(tag: String, page: Int, size: Int, searchType: ImageSearchType): Future<ImageSearchPageWrapper>
+
+  /**
+   * Delete images based on given [imageIds].
+   */
+  fun deleteImages(imageIds: List<String>): Future<Int>
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaServiceMockImpl.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaServiceMockImpl.kt
@@ -149,4 +149,10 @@ class ImageMetaServiceMockImpl : ImageMetaService {
       )
     )
   }
+
+  override fun deleteImages(imageIds: List<String>): Future<Int> {
+    val deleted = images.filter { imageIds.contains(it.id) }
+    images.removeAll(deleted)
+    return Future.succeededFuture(deleted.size)
+  }
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/UserConsumerService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/UserConsumerService.kt
@@ -1,0 +1,90 @@
+package com.instagram_clone.image_service.service
+
+import com.instagram_clone.image_service.config.AppConfig
+import com.instagram_clone.image_service.data.ImageMeta
+import com.instagram_clone.image_service.message_broker.DomainEvent
+import com.instagram_clone.image_service.message_broker.DomainEventType
+import com.instagram_clone.image_service.message_broker.MessageBrokerService
+import io.vertx.core.Future
+import io.vertx.core.logging.LoggerFactory
+
+class UserConsumerService(
+  private val imageMetaService: ImageMetaService,
+  private val messageBrokerService: MessageBrokerService
+) {
+
+  private val logger = LoggerFactory.getLogger("MessageConsumerService")
+
+  private val config = AppConfig.getInstance()
+
+  private fun handleEvent(event: DomainEvent) {
+    when (event.type) {
+      DomainEventType.Deleted -> {
+        try {
+          val data = event.data as LinkedHashMap<*, *>
+          val userId = data["userId"] as String
+          deleteImages(userId)
+            .onSuccess {
+              logger.info("Deleted images for user $userId")
+            }
+            .onFailure { e ->
+              logger.error("Failed to delete images for user $userId, ${e.message}", e)
+            }
+        } catch (e: Exception) {
+          logger.error("Failed to parse user id out of DomainEvent", e)
+        }
+      }
+      else -> logger.debug("Got user event ${event.type.stringValue}")
+    }
+  }
+
+  /**
+   * Delete images based on [userId]. This is an asynchronous method that deletes images
+   * in batches of 20 images.
+   */
+  private fun deleteImages(userId: String, round: Int = 1, deleteCount: Int = 0): Future<Int> {
+    val page = 1
+    val size = 20
+    var expectedDeleteCount = 0
+    var nextPage = false
+    var images = listOf<ImageMeta>()
+    return imageMetaService.getUserImages(userId, page, size)
+      .compose { wrapper ->
+        expectedDeleteCount = wrapper.images.size
+        images = wrapper.images
+        if (wrapper.totalCount > wrapper.count) {
+          nextPage = true
+        }
+        imageMetaService.deleteImages(images.map { it.id })
+      }
+      .compose { count ->
+        if (count != expectedDeleteCount) {
+          logger.warn(
+            "Expected delete count $expectedDeleteCount but it actually was " +
+              "$count for user $userId at round $round"
+          )
+        }
+        publishDeletedImages(images)
+        if (nextPage) {
+          deleteImages(userId, round + 1, deleteCount + count)
+        } else {
+          Future.succeededFuture<Int>(deleteCount + count)
+        }
+      }
+  }
+
+  /**
+   * Publish deleted image events into message broker.
+   */
+  private fun publishDeletedImages(images: List<ImageMeta>) {
+    for (image in images) {
+      messageBrokerService.publishEvent(
+        config.imagesTopic,
+        DomainEvent(
+          DomainEventType.Deleted,
+          image
+        )
+      )
+    }
+  }
+}

--- a/rest-api/src/Server.ts
+++ b/rest-api/src/Server.ts
@@ -84,7 +84,10 @@ export default class Server {
     ) {
         const publicRouter = new Router();
         const protectedRouter = new Router(); // Routes that require access token
-        const authMw = generateAuthMiddleware(authService);
+        const authMw = generateAuthMiddleware(
+            authService,
+            [/^\/images\/([a-f0-9-]{1,36})\/data$/]
+        );
         protectedRouter.use(authMw);
 
         const authController = new AuthController(authService);

--- a/rest-api/src/controllers/ImageController.ts
+++ b/rest-api/src/controllers/ImageController.ts
@@ -35,6 +35,7 @@ import { GetCommentError } from "../client/comments/errors/GetCommentError";
 const allowedFileTypes = ["image/png", "image/jpeg"];
 
 const MAX_IMAGE_SIZE_BYTES = 15728640; // 15MB
+const CACHE_CONTROL_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
 const upload = multer({
   /**
@@ -304,6 +305,7 @@ export class ImageController implements IController {
     try {
       const { type, data } = await this.imageService.getImageData(imageId);
       ctx.body = Buffer.from(data);
+      ctx.set("Cache-Control", `max-age=${CACHE_CONTROL_MAX_AGE_SECONDS}`);
       ctx.type = `image/${type}`;
       ctx.status = 200;
     } catch (e) {

--- a/rest-api/src/middleware/authenticate.ts
+++ b/rest-api/src/middleware/authenticate.ts
@@ -25,9 +25,18 @@ export interface AuthState {
  * @param service The auth service instance
  */
 export function generateAuthMiddleware(
-    service: AuthService
+    service: AuthService,
+    unless?: (string | RegExp)[],
 ): Middleware {
     return async (ctx: RouterContext, next: Next) => {
+        if (Array.isArray(unless)) {
+            for (const path of unless) {
+                if (new RegExp(path).test(ctx.URL.pathname)) {
+                    // Skip authentication
+                    return next();
+                }
+            }
+        }
         const token = getBearerToken(ctx);
         if (!token) {
             throw new RequestError(401);


### PR DESCRIPTION
# Details

Implemented the `Cache-Control` header to image data API.

## Changes
* Set the response header to `Cache-Control: max-age=<30 days in seconds>`
* Skip authorization for the image data API
    * Reading image data won't work e.g. in browsers if the authorization is required (at least based on `Authorization` -header)

## Original issue description

As we are sure that the image data itself doesn't change once it has been uploaded, we can safely set `Cache-Control` headers.