### PR TITLE
User-service Kafka integration

### DIFF
--- a/image-service/conf/config.json
+++ b/image-service/conf/config.json
@@ -11,5 +11,7 @@
   "MONGO_PASSWORD": "image-service",
   "IMAGES_COLLECTION": "image_meta",
   "KAFKA_SERVERS": "localhost:29092",
-  "IMAGES_TOPIC": "images"
+  "IMAGES_TOPIC": "images",
+  "USERS_TOPIC": "users",
+  "KAFKA_CONSUMER_GROUP": "image-service"
 }

--- a/image-service/conf/config.json
+++ b/image-service/conf/config.json
@@ -10,5 +10,6 @@
   "MONGO_USER": "image-service",
   "MONGO_PASSWORD": "image-service",
   "IMAGES_COLLECTION": "image_meta",
-  "KAFKA_SERVERS": "localhost:29092"
+  "KAFKA_SERVERS": "localhost:29092",
+  "IMAGES_TOPIC": "images"
 }

--- a/image-service/docker-compose.yml
+++ b/image-service/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       MONGO_DATABASE: images
       IMAGES_COLLECTION: image_meta
       KAFKA_SERVERS: kafka-dev:9092
+      IMAGES_TOPIC: images
 
   image-db:
     container_name: image-db-dev

--- a/image-service/docker-compose.yml
+++ b/image-service/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       IMAGES_COLLECTION: image_meta
       KAFKA_SERVERS: kafka-dev:9092
       IMAGES_TOPIC: images
+      USERS_TOPIC: users
+      KAFKA_CONSUMER_GROUP: image-service
 
   image-db:
     container_name: image-db-dev

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
@@ -85,6 +85,12 @@ class AppConfig private constructor(json: JsonObject) {
   var kafkaServers: String
     private set
 
+  /**
+   * Kafka topic for images
+   */
+  var imagesTopic: String
+    private set
+
   init {
     grpcHost = json.getString(ConfigConstants.GRPC_HOST)
     grpcPort = json.getInteger(ConfigConstants.GRPC_PORT)
@@ -99,6 +105,7 @@ class AppConfig private constructor(json: JsonObject) {
     imagesCollection = json.getString(ConfigConstants.IMAGES_COLLECTION, "image_meta")
     likesCollection = json.getString(ConfigConstants.LIKES_COLLECTION, "image_likes")
     kafkaServers = json.getString(ConfigConstants.KAFKA_SERVERS)
+    imagesTopic = json.getString(ConfigConstants.IMAGES_TOPIC, "images")
   }
 
   companion object {

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/AppConfig.kt
@@ -91,6 +91,18 @@ class AppConfig private constructor(json: JsonObject) {
   var imagesTopic: String
     private set
 
+  /**
+   * Kafka topic for users
+   */
+  var usersTopic: String
+    private set
+
+  /**
+   * Name / ID of the Kafka consumer group
+   */
+  var consumerGroup: String
+    private set
+
   init {
     grpcHost = json.getString(ConfigConstants.GRPC_HOST)
     grpcPort = json.getInteger(ConfigConstants.GRPC_PORT)
@@ -106,6 +118,8 @@ class AppConfig private constructor(json: JsonObject) {
     likesCollection = json.getString(ConfigConstants.LIKES_COLLECTION, "image_likes")
     kafkaServers = json.getString(ConfigConstants.KAFKA_SERVERS)
     imagesTopic = json.getString(ConfigConstants.IMAGES_TOPIC, "images")
+    usersTopic = json.getString(ConfigConstants.USERS_TOPIC, "users")
+    consumerGroup = json.getString(ConfigConstants.KAFKA_CONSUMER_GROUP, "image-service")
   }
 
   companion object {

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
@@ -74,4 +74,14 @@ object ConfigConstants {
    * Kafka topic for image events
    */
   const val IMAGES_TOPIC = "IMAGES_TOPIC"
+
+  /**
+   * Kafka topic for user events
+   */
+  const val USERS_TOPIC = "USERS_TOPIC"
+
+  /**
+   * Name / ID of the Kafka consumer group
+   */
+  const val KAFKA_CONSUMER_GROUP = "KAFKA_CONSUMER_GROUP"
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/config/ConfigConstants.kt
@@ -69,4 +69,9 @@ object ConfigConstants {
    * Kafka servers value in form of "<host>:<port>"
    */
   const val KAFKA_SERVERS = "KAFKA_SERVERS"
+
+  /**
+   * Kafka topic for image events
+   */
+  const val IMAGES_TOPIC = "IMAGES_TOPIC"
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/DomainEvents.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/DomainEvents.kt
@@ -1,26 +1,34 @@
 package com.instagram_clone.image_service.message_broker
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.vertx.core.json.JsonObject
 
 /**
  * Domain event type for resources
  */
 enum class DomainEventType(val stringValue: String) {
+  @JsonProperty("CREATED")
   Created("CREATED"),
-  Updated("UPDATED"),
+
+  @JsonProperty("DELETED")
   Deleted("DELETED"),
-  Liked("LIKED")
+
+  @JsonProperty("LIKED")
+  Liked("LIKED"),
+
+  @JsonProperty("NOT_SET")
+  NotSet("NOT_SET")
 }
 
 data class DomainEvent(
-  val type: DomainEventType,
-  val entity: Any
+  val type: DomainEventType = DomainEventType.NotSet,
+  val data: Any = ""
 ) : BrokerEvent {
 
   override fun jsonSerialize(): String {
     return JsonObject()
       .put("type", type.stringValue)
-      .put("data", JsonObject.mapFrom(entity))
+      .put("data", JsonObject.mapFrom(data))
       .encode()
   }
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
@@ -42,6 +42,7 @@ class KafkaService(
             val valueAsJson = JsonObject(record.value())
             val event = valueAsJson.mapTo(DomainEvent::class.java)
             handler(event)
+            consumer.commit()
           } catch (e: DecodeException) {
             logger.warn("Kafka consumer event received in unexpected format, ${e.message}", e)
           } catch (e: Exception) {

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/KafkaService.kt
@@ -1,6 +1,9 @@
 package com.instagram_clone.image_service.message_broker
 
+import io.vertx.core.json.DecodeException
+import io.vertx.core.json.JsonObject
 import io.vertx.core.logging.LoggerFactory
+import io.vertx.kafka.client.consumer.KafkaConsumer
 import io.vertx.kafka.client.producer.KafkaProducer
 import io.vertx.kafka.client.producer.KafkaProducerRecord
 
@@ -8,7 +11,8 @@ import io.vertx.kafka.client.producer.KafkaProducerRecord
  * Kafka message broker service class.
  */
 class KafkaService(
-  private val producer: KafkaProducer<Nothing, String>
+  private val producer: KafkaProducer<Nothing, String>,
+  private val consumer: KafkaConsumer<Nothing, String>
 ) : MessageBrokerService {
 
   private val logger = LoggerFactory.getLogger("KafkaService")
@@ -23,6 +27,29 @@ class KafkaService(
     producer.send(record) {
       if (!it.succeeded()) {
         logger.error("Failed to publish event to kafka topic $queue", it.cause())
+      }
+    }
+  }
+
+  /**
+   * Subscribe to given [queue].
+   */
+  override fun subscribe(queue: String, handler: (ar: DomainEvent) -> Unit) {
+    consumer.subscribe(queue) {
+      if (it.succeeded()) {
+        consumer.handler { record ->
+          try {
+            val valueAsJson = JsonObject(record.value())
+            val event = valueAsJson.mapTo(DomainEvent::class.java)
+            handler(event)
+          } catch (e: DecodeException) {
+            logger.warn("Kafka consumer event received in unexpected format, ${e.message}", e)
+          } catch (e: Exception) {
+            logger.error("Unexpected exception while handling consumer event: ${e.message}", e)
+          }
+        }
+      } else {
+        logger.error("Failed to subscribe to queue \"$queue\"")
       }
     }
   }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/MessageBrokerService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/message_broker/MessageBrokerService.kt
@@ -9,4 +9,9 @@ interface MessageBrokerService {
    * Publish an [event] to [queue].
    */
   fun publishEvent(queue: String, event: BrokerEvent)
+
+  /**
+   * Subscribe to given [queue].
+   */
+  fun subscribe(queue: String, handler: (ar: DomainEvent) -> Unit)
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileService.kt
@@ -22,4 +22,9 @@ interface ImageFileService {
    * Get image file from disk.
    */
   fun getImageFile(id: String): Future<ByteArray>
+
+  /**
+   * Delete a batch of images from disk.
+   */
+  fun deleteImageFiles(ids: List<String>): Future<Int>
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileServiceVertxImpl.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageFileServiceVertxImpl.kt
@@ -2,6 +2,7 @@ package com.instagram_clone.image_service.service
 
 import com.instagram_clone.image_service.config.AppConfig
 import com.instagram_clone.image_service.exception.NotFoundException
+import io.vertx.core.CompositeFuture
 import io.vertx.core.Future
 import io.vertx.core.Promise
 import io.vertx.core.Vertx
@@ -61,6 +62,11 @@ class ImageFileServiceVertxImpl(
         }
       }
     return promise.future()
+  }
+
+  override fun deleteImageFiles(ids: List<String>): Future<Int> {
+    return CompositeFuture.join(ids.map { deleteImageFile(it) })
+      .compose { Future.succeededFuture(ids.size) }
   }
 
   /**

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaService.kt
@@ -47,4 +47,9 @@ interface ImageMetaService {
    * Get images based on search tag.
    */
   fun searchImagesByTag(tag: String, page: Int, size: Int, searchType: ImageSearchType): Future<ImageSearchPageWrapper>
+
+  /**
+   * Delete images based on given [imageIds].
+   */
+  fun deleteImages(imageIds: List<String>): Future<Int>
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaServiceMockImpl.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/ImageMetaServiceMockImpl.kt
@@ -149,4 +149,10 @@ class ImageMetaServiceMockImpl : ImageMetaService {
       )
     )
   }
+
+  override fun deleteImages(imageIds: List<String>): Future<Int> {
+    val deleted = images.filter { imageIds.contains(it.id) }
+    images.removeAll(deleted)
+    return Future.succeededFuture(deleted.size)
+  }
 }

--- a/image-service/src/main/kotlin/com/instagram_clone/image_service/service/UserConsumerService.kt
+++ b/image-service/src/main/kotlin/com/instagram_clone/image_service/service/UserConsumerService.kt
@@ -1,0 +1,90 @@
+package com.instagram_clone.image_service.service
+
+import com.instagram_clone.image_service.config.AppConfig
+import com.instagram_clone.image_service.data.ImageMeta
+import com.instagram_clone.image_service.message_broker.DomainEvent
+import com.instagram_clone.image_service.message_broker.DomainEventType
+import com.instagram_clone.image_service.message_broker.MessageBrokerService
+import io.vertx.core.Future
+import io.vertx.core.logging.LoggerFactory
+
+class UserConsumerService(
+  private val imageMetaService: ImageMetaService,
+  private val messageBrokerService: MessageBrokerService
+) {
+
+  private val logger = LoggerFactory.getLogger("MessageConsumerService")
+
+  private val config = AppConfig.getInstance()
+
+  private fun handleEvent(event: DomainEvent) {
+    when (event.type) {
+      DomainEventType.Deleted -> {
+        try {
+          val data = event.data as LinkedHashMap<*, *>
+          val userId = data["userId"] as String
+          deleteImages(userId)
+            .onSuccess {
+              logger.info("Deleted images for user $userId")
+            }
+            .onFailure { e ->
+              logger.error("Failed to delete images for user $userId, ${e.message}", e)
+            }
+        } catch (e: Exception) {
+          logger.error("Failed to parse user id out of DomainEvent", e)
+        }
+      }
+      else -> logger.debug("Got user event ${event.type.stringValue}")
+    }
+  }
+
+  /**
+   * Delete images based on [userId]. This is an asynchronous method that deletes images
+   * in batches of 20 images.
+   */
+  private fun deleteImages(userId: String, round: Int = 1, deleteCount: Int = 0): Future<Int> {
+    val page = 1
+    val size = 20
+    var expectedDeleteCount = 0
+    var nextPage = false
+    var images = listOf<ImageMeta>()
+    return imageMetaService.getUserImages(userId, page, size)
+      .compose { wrapper ->
+        expectedDeleteCount = wrapper.images.size
+        images = wrapper.images
+        if (wrapper.totalCount > wrapper.count) {
+          nextPage = true
+        }
+        imageMetaService.deleteImages(images.map { it.id })
+      }
+      .compose { count ->
+        if (count != expectedDeleteCount) {
+          logger.warn(
+            "Expected delete count $expectedDeleteCount but it actually was " +
+              "$count for user $userId at round $round"
+          )
+        }
+        publishDeletedImages(images)
+        if (nextPage) {
+          deleteImages(userId, round + 1, deleteCount + count)
+        } else {
+          Future.succeededFuture<Int>(deleteCount + count)
+        }
+      }
+  }
+
+  /**
+   * Publish deleted image events into message broker.
+   */
+  private fun publishDeletedImages(images: List<ImageMeta>) {
+    for (image in images) {
+      messageBrokerService.publishEvent(
+        config.imagesTopic,
+        DomainEvent(
+          DomainEventType.Deleted,
+          image
+        )
+      )
+    }
+  }
+}

--- a/rest-api/src/Server.ts
+++ b/rest-api/src/Server.ts
@@ -84,7 +84,10 @@ export default class Server {
     ) {
         const publicRouter = new Router();
         const protectedRouter = new Router(); // Routes that require access token
-        const authMw = generateAuthMiddleware(authService);
+        const authMw = generateAuthMiddleware(
+            authService,
+            [/^\/images\/([a-f0-9-]{1,36})\/data$/]
+        );
         protectedRouter.use(authMw);
 
         const authController = new AuthController(authService);

--- a/rest-api/src/controllers/ImageController.ts
+++ b/rest-api/src/controllers/ImageController.ts
@@ -35,6 +35,7 @@ import { GetCommentError } from "../client/comments/errors/GetCommentError";
 const allowedFileTypes = ["image/png", "image/jpeg"];
 
 const MAX_IMAGE_SIZE_BYTES = 15728640; // 15MB
+const CACHE_CONTROL_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
 const upload = multer({
   /**
@@ -304,6 +305,7 @@ export class ImageController implements IController {
     try {
       const { type, data } = await this.imageService.getImageData(imageId);
       ctx.body = Buffer.from(data);
+      ctx.set("Cache-Control", `max-age=${CACHE_CONTROL_MAX_AGE_SECONDS}`);
       ctx.type = `image/${type}`;
       ctx.status = 200;
     } catch (e) {

--- a/rest-api/src/middleware/authenticate.ts
+++ b/rest-api/src/middleware/authenticate.ts
@@ -25,9 +25,18 @@ export interface AuthState {
  * @param service The auth service instance
  */
 export function generateAuthMiddleware(
-    service: AuthService
+    service: AuthService,
+    unless?: (string | RegExp)[],
 ): Middleware {
     return async (ctx: RouterContext, next: Next) => {
+        if (Array.isArray(unless)) {
+            for (const path of unless) {
+                if (new RegExp(path).test(ctx.URL.pathname)) {
+                    // Skip authentication
+                    return next();
+                }
+            }
+        }
         const token = getBearerToken(ctx);
         if (!token) {
             throw new RequestError(401);

--- a/user-service/app/account_consumer.py
+++ b/user-service/app/account_consumer.py
@@ -1,0 +1,94 @@
+from threading import Thread
+from kafka import KafkaConsumer
+import json
+import logging
+
+from app.config import kafka_consumer_config
+from app.db.database import Database
+from app.models.user import User, map_from_json as user_from_json
+from app.domain_event import DomainEvent, DomainEventType
+
+logger = logging.getLogger("app.account_consumer")
+
+class AccountConsumer():
+    """Class consuming account events. Works with threads."""
+
+    def __init__(self, database: Database):
+        super().__init__()
+        self.consumer = KafkaConsumer(
+            group_id=kafka_consumer_config["group_id"],
+            bootstrap_servers=[kafka_consumer_config["bootstrap_servers"]],
+            auto_offset_reset="earliest",
+            enable_auto_commit=True,
+            value_deserializer=AccountConsumer.decode_json,
+            consumer_timeout_ms=2000 # Stop consuming after 2 seconds of idle
+        )
+        self.db = database
+        self.shutting_down = False
+        self.main_thread = None #type: Thread
+
+    @staticmethod
+    def decode_json(message):
+        """JSON message decoder to be used in Kafka consumer."""
+        try:
+            return json.loads(message.decode("ascii"))
+        except Exception as e:
+            logger.warn("Failed to decode message as JSON, {}".format(str(e)))
+
+    def consume_batch(self):
+        """Consume a batch of events. The consumer will iterate until a period of
+        consumer_timeout_ms is passed without new messages."""
+        for m in self.consumer:
+            try:
+                event = DomainEvent.map_from_json(m.value)
+                if event.type is DomainEventType.CREATED:
+                    self.handle_create(event.data)
+                elif event.type is DomainEventType.DELETED:
+                    self.handle_delete(event.data)
+                else:
+                    logger.info("Unexpected domain event type: {}".format(event.type))
+            except Exception as e:
+                logger.error("Received invalid data from Kafka", e)
+
+    def launch_child_threads(self):
+        """Launch consumer threads in a while loop as long as we are not shutting down. Each
+        consumer thread will close after being 2 seconds being idle."""
+        logger.info("Main account consumer thread started")
+
+        while not self.shutting_down:
+            thread = Thread(target=self.consume_batch)
+            thread.start()
+            thread.join()
+
+        logger.info("Main account thread consumer stopped")
+
+
+    def start(self):
+        """"Start the consuming by launching a main background thread that will manage
+        consuming process by spawning a consumer thread one after another."""
+        topic = kafka_consumer_config["topic"]
+        self.consumer.subscribe(topic)
+        logger.info("AccountConsumer subscribed to topic {}".format(topic))
+        self.main_thread = Thread(target=self.launch_child_threads)
+        self.main_thread.start()
+
+    def stop(self):
+        """Stop the consumer and wait for threads to finish."""
+        self.shutting_down = True
+        if self.main_thread  is not None:
+            self.main_thread.join()
+            self.consumer.close()
+
+    def handle_create(self, data):
+        try:
+            user = user_from_json(data)
+            self.db.createUser(user)
+        except Exception as e:
+            logger.error("Failed to create user from user event", e)
+
+    def handle_delete(self, data):
+        try:
+            user = user_from_json(data)
+            self.db.deleteUserById(user.id)
+        except Exception as e:
+            logger.error("Failed to delete user from user event", e)

--- a/user-service/app/config.py
+++ b/user-service/app/config.py
@@ -33,3 +33,8 @@ kafka_consumer_config = {
     'bootstrap_servers': os.getenv("KAFKA_SERVERS", "localhost:29092"),
     'group_id': os.getenv("KAFKA_CONSUMER_GROUP", "user-service")
 }
+
+kafka_producer_config = {
+    'bootstrap_servers': os.getenv("KAFKA_SERVERS", "localhost:29092"),
+    'topic': os.getenv("KAFKA_USERS_TOPIC", "users")
+}

--- a/user-service/app/config.py
+++ b/user-service/app/config.py
@@ -27,3 +27,9 @@ grpc_config = {
     'port': os.getenv("GRPC_PORT", 8080),
     'app_env': os.getenv("APP_ENV", "development")
 }
+
+kafka_consumer_config = {
+    'topic': os.getenv("KAFKA_ACCOUNTS_TOPIC", "accounts"),
+    'bootstrap_servers': os.getenv("KAFKA_SERVERS", "localhost:29092"),
+    'group_id': os.getenv("KAFKA_CONSUMER_GROUP", "user-service")
+}

--- a/user-service/app/db/database.py
+++ b/user-service/app/db/database.py
@@ -71,7 +71,7 @@ class Database():
         session = Session(bind=self.engine)
         return session.query(User).filter_by(username=username).first()
 
-    def createUser(self, user: User):
+    def createUser(self, user: User) -> User:
         """Create a new user into database.
         
         Arguments:
@@ -93,6 +93,7 @@ class Database():
 
         session.add(user)
         session.commit()
+        return user
 
     def getAllUsers(self, page: int = 1, size: int = 20) -> Page:
         """Find all users as paginated result set.
@@ -118,7 +119,7 @@ class Database():
         count = session.query(User).count()
         return Page(page, size, count, users)
 
-    def deleteUserById(self, user_id: str):
+    def deleteUserById(self, user_id: str) -> User:
         """Delete a user by ID.
         
         Arguments:
@@ -135,6 +136,7 @@ class Database():
             raise EntityNotFoundError
         session.delete(user)
         session.commit()
+        return user
 
 
 

--- a/user-service/app/domain_event.py
+++ b/user-service/app/domain_event.py
@@ -1,0 +1,29 @@
+from enum import Enum
+import json
+
+class DomainEventType(Enum):
+    CREATED = "CREATED"
+    UPDATED = "UPDATED"
+    DELETED = "DELETED"
+    NOT_SET = "NOT_SET"
+
+class DomainEvent():
+
+    def __init__(self, event_type: DomainEventType, data):
+        super().__init__()
+        self.type = event_type
+        self.data = data
+
+    def json_serialize(self):
+        return json.dumps({
+            'type': self.type,
+            'data': self.data
+        })
+
+    @staticmethod
+    def map_from_json(json_object):
+        type_plain = json_object["type"]
+        data_plain = json_object["data"]
+        if type_plain in DomainEventType.__members__:
+            return DomainEvent(DomainEventType[type_plain], data_plain)
+        raise Exception("Domain event type was not recognized")

--- a/user-service/app/domain_event.py
+++ b/user-service/app/domain_event.py
@@ -14,11 +14,11 @@ class DomainEvent():
         self.type = event_type
         self.data = data
 
-    def json_serialize(self):
-        return json.dumps({
-            'type': self.type,
+    def to_dict(self) -> dict:
+        return {
+            'type': self.type.value,
             'data': self.data
-        })
+        }
 
     @staticmethod
     def map_from_json(json_object):

--- a/user-service/app/models/user.py
+++ b/user-service/app/models/user.py
@@ -18,6 +18,15 @@ class User(Base):
             self.created_at,
             self.updated_at
         )
+    
+    def to_dict(self) -> dict:
+        """Convert this user to a dict."""
+        return {
+            'id': str(self.id),
+            'username': str(self.username),
+            'created_at': self.created_at.isoformat(),
+            'updated_at': self.updated_at.isoformat()
+        }
 
 def map_from_json(json_data) -> User:
     """Create an instance of User out of JSON data.

--- a/user-service/app/models/user.py
+++ b/user-service/app/models/user.py
@@ -18,3 +18,24 @@ class User(Base):
             self.created_at,
             self.updated_at
         )
+
+def map_from_json(json_data) -> User:
+    """Create an instance of User out of JSON data.
+    
+    Arguments:
+
+        json_data {dict} -- JSON data in a dictionary
+    
+    Returns:
+
+        User -- The created user instance
+
+    Raises:
+
+        AssertionError - Received unexpected data format
+    """
+    id_raw = json_data["id"]
+    username_raw = json_data["username"]
+    assert isinstance(id_raw, str), "Received unexpected JSON data: {json_data}"
+    assert isinstance(username_raw, str), "Received unexpected JSON data: {json_data}"
+    return User(id=id_raw, username=username_raw)

--- a/user-service/app/user_producer.py
+++ b/user-service/app/user_producer.py
@@ -1,0 +1,36 @@
+import json
+import logging
+from kafka import KafkaProducer
+from app.config import kafka_producer_config
+from app.domain_event import DomainEvent
+
+logger = logging.getLogger("app.user_producer")
+
+class UserProducer():
+    """User event producer class that can be used to publish messages to Kafka."""
+
+    def __init__(self):
+        super().__init__()
+        self.producer = KafkaProducer(
+            bootstrap_servers=[kafka_producer_config["bootstrap_servers"]],
+            value_serializer=lambda m: json.dumps(m).encode("ascii")
+        )
+    
+    def error_callback(self, e: Exception):
+        logger.error("Failed to publish an event", exc_info=e)
+
+    def publish(self, topic: str, event: DomainEvent):
+        """Publish an event to given topic.
+        
+        Arguments:
+
+            topic {str} -- The target topic
+
+            event {DomainEvent} -- The domain event to publish
+        """
+        self.producer.send(topic, event.to_dict()).add_errback(self.error_callback)
+
+    def clean_up(self):
+        """Cleanup the procuder. This will block until all messages has been flushed."""
+        self.producer.flush()
+        self.producer.close(2)

--- a/user-service/app/user_service.py
+++ b/user-service/app/user_service.py
@@ -1,0 +1,46 @@
+from app.db.database import Database
+from app.models.user import User
+from app.user_producer import UserProducer
+from app.config import kafka_producer_config
+from app.domain_event import DomainEvent, DomainEventType
+
+users_topic = kafka_producer_config["topic"]
+
+class UserService():
+    """User service class that handles domain specific operations. Use this when
+    you want to publish domain events to message broker."""
+
+    def __init__(self, database: Database, producer: UserProducer):
+        super().__init__()
+        self.db = database
+        self.producer = producer
+
+    def createUser(self, user: User) -> User:
+        """Create an user into database and publish user created event.
+        
+        Arguments:
+    
+            user {User} -- The user
+        
+        Returns:
+
+            User -- The created user
+        """
+        user = self.db.createUser(user)
+        self.producer.publish(users_topic, DomainEvent(DomainEventType.CREATED, user.to_dict()))
+        return user
+
+    def deleteUserById(self, user_id: str) -> User:
+        """Delete an user by id and publish user deleted event.
+        
+        Arguments:
+
+            user_id {str} -- User's ID
+        
+        Returns:
+
+            User -- The deleted user
+        """
+        user = self.db.deleteUserById(user_id)
+        self.producer.publish(users_topic, DomainEvent(DomainEventType.DELETED, user.to_dict()))
+        return user

--- a/user-service/app/user_servicer.py
+++ b/user-service/app/user_servicer.py
@@ -1,0 +1,72 @@
+import logging
+from app.codegen import user_service_pb2, user_service_pb2_grpc
+from app.db.database import Database
+from app.models.user import User
+from app.db import exceptions
+
+
+class UserServicer(user_service_pb2_grpc.UserServicer): 
+    """Class implementing the gRPC API"""
+
+    def __init__(self, database: Database):
+        self.db = database
+
+    def Create(self, request, context): 
+        """Creates a new user"""
+        username = request.username
+        account_id = request.account_id
+        user = User(id=account_id, username=username)
+        logging.info("Received account id to create: " + account_id + "\n" + "recieved username: " + username)
+        try:
+            self.db.createUser(user)
+            response = user_service_pb2.CreateUserResponse(
+                status = "USER_CREATED"
+            )
+        except exceptions.IdExistsError:
+            response = user_service_pb2.CreateUserResponse(
+                status = "ACCOUNT_ID_ALREADY_EXISTS"
+            )
+        except exceptions.UsernameExistsError:
+            response = user_service_pb2.CreateUserResponse(
+                status = "USERNAME_ALREADY_EXISTS"
+            )
+        return response
+
+    def Delete(self, request, context):
+        """Delete a user"""
+        account_id = request.account_id
+        logging.info("Received account id to delete: " + account_id) 
+        try:
+            self.db.deleteUserById(account_id)
+            response = user_service_pb2.DeleteUserResponse(
+                status = "USER_DELETED"
+            )
+        except exceptions.EntityNotFoundError:
+            response = user_service_pb2.DeleteUserResponse(
+                status = "ACCOUNT_ID_NOT_EXIST"
+            )
+        return response
+
+    def GetUser(self, request, context):
+        """Gets a user.
+           gRPC calls this method when clients call the GetUser rpc (method).
+        Arguments:
+            request (GetUserRequest): The incoming request.
+            context: The gRPC connection context.
+        
+        Returns:
+            user (User): A user.
+        """
+        account_id = request.account_id
+        logging.info("Received account id: " + account_id)
+        result= self.db.findUserById(account_id)
+        user = user_service_pb2.UserInfo()
+        user.id = result.id
+        user.username = result.username
+        user.created_at = result.created_at.isoformat()
+        user.updated_at = result.updated_at.isoformat()
+        response = user_service_pb2.GetUserResponse(
+            user = user
+        )
+        
+        return response

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       - .db.env
     environment:
       POSTGRES_HOST: user-db-dev
+      KAFKA_SERVERS: kafka-dev:9092
+      KAFKA_ACCOUNTS_TOPIC: accounts
+      KAFKA_USERS_TOPIC: users
+      KAFKA_CONSUMER_GROUP: user-service
 
   user-db:
     container_name: user-db-dev

--- a/user-service/requirements.txt
+++ b/user-service/requirements.txt
@@ -3,6 +3,7 @@ chardet==3.0.4
 grpcio==1.27.1
 grpcio-tools==1.27.1
 idna==2.9
+kafka-python==2.0.1
 protobuf==3.11.3
 psycopg2==2.8.4
 python-consul==1.1.0

--- a/user-service/server.py
+++ b/user-service/server.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
     logging.debug("Stopped gRPC server")
 
     consumer.stop()
+    producer.clean_up()
 
     if database.authenticate():    
         database.connection.close()

--- a/user-service/server.py
+++ b/user-service/server.py
@@ -3,13 +3,12 @@ import time
 import grpc
 import platform
 import logging
-from app.codegen import user_service_pb2, user_service_pb2_grpc
+from app.codegen import user_service_pb2_grpc
 from app.db.database import Database
-from app.models.user import User
 from app.config import database_config, grpc_config
-from app.db import exceptions
 from app.service_discovery import ServiceDiscovery
 from app.utils import SignalDetector
+from app.user_servicer import UserServicer
 
 log_level = logging.DEBUG if grpc_config["app_env"] is "development" else logging.INFO
 logging.basicConfig(format="%(asctime)s %(process)d %(levelname)s %(name)s - %(message)s", level=log_level)
@@ -41,73 +40,7 @@ def get_error_handler(sd: ServiceDiscovery):
             logging.warn("Re-registration to Consul failed: {e}")
 
     return error_handler
-
-class UserServicer(user_service_pb2_grpc.UserServicer): 
-    """Class implementing the gRPC API"""
-
-    def __init__(self, database: Database):
-        self.db = database
-
-    def Create(self, request, context): 
-        """Creates a new user"""
-        username = request.username
-        account_id = request.account_id
-        user = User(id=account_id, username=username)
-        logging.info("Received account id to create: " + account_id + "\n" + "recieved username: " + username)
-        try:
-            self.db.createUser(user)
-            response = user_service_pb2.CreateUserResponse(
-                status = "USER_CREATED"
-            )
-        except exceptions.IdExistsError:
-            response = user_service_pb2.CreateUserResponse(
-                status = "ACCOUNT_ID_ALREADY_EXISTS"
-            )
-        except exceptions.UsernameExistsError:
-            response = user_service_pb2.CreateUserResponse(
-                status = "USERNAME_ALREADY_EXISTS"
-            )
-        return response
-
-    def Delete(self, request, context):
-        """Delete a user"""
-        account_id = request.account_id
-        logging.info("Received account id to delete: " + account_id) 
-        try:
-            self.db.deleteUserById(account_id)
-            response = user_service_pb2.DeleteUserResponse(
-                status = "USER_DELETED"
-            )
-        except exceptions.EntityNotFoundError:
-            response = user_service_pb2.DeleteUserResponse(
-                status = "ACCOUNT_ID_NOT_EXIST"
-            )
-        return response
-
-    def GetUser(self, request, context):
-        """Gets a user.
-           gRPC calls this method when clients call the GetUser rpc (method).
-        Arguments:
-            request (GetUserRequest): The incoming request.
-            context: The gRPC connection context.
-        
-        Returns:
-            user (User): A user.
-        """
-        account_id = request.account_id
-        logging.info("Received account id: " + account_id)
-        result= self.db.findUserById(account_id)
-        user = user_service_pb2.UserInfo()
-        user.id = result.id
-        user.username = result.username
-        user.created_at = result.created_at.isoformat()
-        user.updated_at = result.updated_at.isoformat()
-        response = user_service_pb2.GetUserResponse(
-            user = user
-        )
-        
-        return response
-            
+  
 
 if __name__ == "__main__":
     # Run a gRPC server with one thread.


### PR DESCRIPTION
# Details

Implemented the Kafka integration to `user-service`.

## Changes
* Some restructuring
    * Moved the gRPC service implementation to it's own file
* Accounts consumer implemented
    * Create or delete users based on events
    * The `kafka` module for Python is odd, no callback handlers or anything asynchronous for consuming events -> use threads
        * The `AccountsConsumer` launches a "main" thread that manages the consuming process
            * The main thread loops until a stop flag has been set to false; during each loop, we let a new consumer consume events in it's own thread
            * The consumer stops consuming after `KafkaConsumer` constructor option `consumer_timeout_ms` has been reached (no new messages received during that time)
* Users producer implemented
    * Publish in similar manner as in other services
* Wrapped user creation and user deletion into `UserService` -class
    * No time to implement the others, but those were the most important ones as they're generating events to Kafka
    * Other persistence operations are done by using directly `Database` -class

Overall quite a lot done in short period of time, so bugs are very likely 😅

## Original issue description

Publish user events and subscribe to account events in `user-service`.